### PR TITLE
Removing space from log/event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ FirebaseCore.configure();
 Ti.API.info('App Instance ID: ' + FirebaseAnalytics.appInstanceID);
 
 // Log to the Firebase console
-FirebaseAnalytics.log('My Event', { /* Optional arguments */ });
+FirebaseAnalytics.log('My_Event', { /* Optional arguments */ });
 
 // Set user-property string
 FirebaseAnalytics.setUserPropertyString({
-  name: 'My Name',
+  name: 'My_Name',
   value: 'My Value'
 });
 


### PR DESCRIPTION
This error was showing up in the Android logs:
```
[ERROR] FA: Name must consist of letters, digits or _ (underscores). Type, name: event, My Event
[ERROR] FA: Name must consist of letters, digits or _ (underscores). Type, name: user property, My Name
```