### PR TITLE
Fixed `setCurrentScreen must be called from the main thread` warning

### DIFF
--- a/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
+++ b/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
@@ -19,6 +19,7 @@ import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.util.TiConvert;
 
 import android.os.Bundle;
+import android.app.Activity;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.analytics.FirebaseAnalytics.Param;
@@ -67,7 +68,7 @@ public class TitaniumFirebaseAnalyticsModule extends KrollModule
   {
     this.analyticsInstance().setUserProperty(TiConvert.toString(parameters, "name"), TiConvert.toString(parameters, "value"));
   }
-  
+
   @Kroll.method @Kroll.setProperty
   public void setUserID(String id)
   {
@@ -78,14 +79,21 @@ public class TitaniumFirebaseAnalyticsModule extends KrollModule
   public void setScreenNameAndScreenClass(KrollDict parameters)
   {
     if (!parameters.containsKey("screenName")) {
-      Log.e(LCAT, "Unable to set current screen without the missing \"screenName\" key"); 
+      Log.e(LCAT, "Unable to set current screen without the missing \"screenName\" key");
       return;
     }
 
-    String screenName = parameters.getString("screenName");
-    String screenClass = parameters.optString("screenClass", "TiController");
-    
-    this.analyticsInstance().setCurrentScreen(getActivity(), screenName, screenClass);
+    final String screenName = parameters.getString("screenName");
+    final String screenClass = parameters.optString("screenClass", "TiController");
+    final Activity currentActivity = getActivity();
+    final FirebaseAnalytics instance = analyticsInstance();
+
+    currentActivity.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        instance.setCurrentScreen(currentActivity, screenName, screenClass);
+      }
+    });
   }
 
   private static Bundle mapToBundle(Map<String, Object> map)

--- a/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
+++ b/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
@@ -85,13 +85,12 @@ public class TitaniumFirebaseAnalyticsModule extends KrollModule
 
     final String screenName = parameters.getString("screenName");
     final String screenClass = parameters.optString("screenClass", "TiController");
-    final Activity currentActivity = getActivity();
     final FirebaseAnalytics instance = analyticsInstance();
 
-    currentActivity.runOnUiThread(new Runnable() {
+    getActivity().runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        instance.setCurrentScreen(currentActivity, screenName, screenClass);
+        instance.setCurrentScreen(TiApplication.getInstance().getCurrentActivity(), screenName, screenClass);
       }
     });
   }


### PR DESCRIPTION
This PR solves a problem that caused calls to `setScreenNameAndScreenClass()` to be ignored on Android. This was initially reported in #19.

The only problem I'm having now is that `screen_view` events are now logged twice per page when I call `setScreenNameAndScreenClass()` and automatic screen tracking is enabled. From [this other issue](https://github.com/firebase/firebase-ios-sdk/issues/1894#issuecomment-439231798) in the Firebase iOS SDK repo, it looks like this is a normal behavior, but I'm not sure.