### PR TITLE
fix(android): add integer/double/float value conversion

### DIFF
--- a/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
+++ b/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
@@ -124,6 +124,12 @@ public class TitaniumFirebaseAnalyticsModule extends KrollModule
 					Log.e("FirebaseAnalytics",
 						  "Unable to put '" + key + "' value into bundle: " + e.getLocalizedMessage(), e);
 				}
+			} else if (val instanceof Double) {
+				bundle.putDouble(key, TiConvert.toDouble(val));
+			} else if (val instanceof Float) {
+				bundle.putDouble(key, TiConvert.toFloat(val));
+			} else if (val instanceof Integer) {
+				bundle.putDouble(key, TiConvert.toInt(val));
 			} else {
 				bundle.putString(key, TiConvert.toString(val));
 			}


### PR DESCRIPTION
This solves an issue when I was trying to send an ecommerce event like `add_to_cart` that has a parameter [`value`](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Param.html#public-static-final-string-value) that only accepts a `Long` or a `Double` value. 

Sending a `String` will raise the error code 18 as described here: https://firebase.google.com/docs/analytics/errors. 