### PR TITLE
Android: Update dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.google.firebase:firebase-analytics:17.3.0'
+	implementation 'com.google.firebase:firebase-analytics:17.5.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.google.firebase:firebase-analytics:17.5.0'
+	implementation 'com.google.firebase:firebase-analytics:18.0.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.0.0
+version: 4.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-analytics

--- a/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
+++ b/android/src/firebase/analytics/TitaniumFirebaseAnalyticsModule.java
@@ -97,7 +97,9 @@ public class TitaniumFirebaseAnalyticsModule extends KrollModule
 			@Override
 			public void run()
 			{
-				instance.setCurrentScreen(TiApplication.getInstance().getCurrentActivity(), screenName, screenClass);
+				Bundle bundle = new Bundle(1);
+				bundle.putString(screenName, screenClass);
+				instance.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle);
 			}
 		});
 	}


### PR DESCRIPTION
Update dependencies:
* com.google.firebase:firebase-analytics:18.0.0

Update:
* `setCurrentScreen` is deprecated, moved to `logEvent`

[firebase.analytics-android-4.0.1.zip](https://github.com/hansemannn/titanium-firebase-analytics/files/5541311/firebase.analytics-android-4.0.1.zip)
